### PR TITLE
Update readme (duplicated install command, remove $ from publish command code block"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Blade MDI adds Material Design Icons as Laravel Blade UI Kit components. For mor
 You can install the package via composer:
 
 ```bash
-composer require composer require postare/blade-mdi
+composer require postare/blade-mdi
 ```
 
 This is not required, but if you want to publish the SVGs locally, you can do so:
 
 ```bash
-$ php artisan vendor:publish --provider="Postare\BladeMdi\BladeMdiServiceProvider" --tag="blade-mdi"
+php artisan vendor:publish --provider="Postare\BladeMdi\BladeMdiServiceProvider" --tag="blade-mdi"
 ```
 
 ## 🙌 Usage


### PR DESCRIPTION
Remove double "composer require composer require", and remove "$" prefix in the publish command, as this is very very annoying when you double-click-to-select-entire-line on a code-block and now you have a damned $ in there breaking your flow, i could elaborate on my hatred for this practice, but this is a mere PR to fix an issue quickly in the middle of the night aifhwoiehng